### PR TITLE
chore: use example- prefix for sample resource names

### DIFF
--- a/docs/placeholders.json
+++ b/docs/placeholders.json
@@ -1,10 +1,10 @@
 {
   "REPLACE_COMPONENT_NAME": {
-    "description": "The component name (lowercase, hyphenated, e.g. my-component)",
-    "example": "my-component"
+    "description": "The component name (lowercase, hyphenated, e.g. example-component)",
+    "example": "example-component"
   },
   "REPLACE_REPO_NAME": {
     "description": "The GitHub repository name",
-    "example": "my-component"
+    "example": "example-component"
   }
 }

--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -3,7 +3,7 @@
 # Use $${VAR_NAME} syntax for templatefile() variables (double $ escapes the interpolation).
 # Example:
 #   write_files:
-#     - path: /opt/my-component/config.env
+#     - path: /opt/example-component/config.env
 #       content: |
 #         TARGET=$${target_fqdn}
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  # TODO: Set this to your component name (e.g., "my-component")
+  # TODO: Set this to your component name (e.g., "example-component")
   component = "REPLACE_COMPONENT_NAME"
 
   # --- Deployer resolution (4-tier fallback) ---


### PR DESCRIPTION
Standardizes sample resource names on the ecosystem `example-` convention.

Replaces the `my-component` placeholder with `example-component` in:
- `terraform/locals.tf` (comment)
- `terraform/cloud-init.yaml` (example path)
- `docs/placeholders.json` (example values)

Part of the ecosystem-wide naming-convention standardization.

Closes #38