### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -13,7 +13,7 @@
     ],
     "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "vscode-xcsh": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
     "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [


### PR DESCRIPTION
Closes #64

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .claude/governance.json