### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/03-deploy.mdx
+++ b/docs/ar/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: النشر
 description: شرح تفصيلي لعملية النشر باستخدام Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/de/03-deploy.mdx
+++ b/docs/de/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: Bereitstellung
 description: Terraform-Bereitstellung – Schritt-für-Schritt-Anleitung
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/es/03-deploy.mdx
+++ b/docs/es/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: Despliegue
 description: Guía paso a paso del despliegue con Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/fr/03-deploy.mdx
+++ b/docs/fr/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: Déploiement
 description: Guide de déploiement avec Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/hi/03-deploy.mdx
+++ b/docs/hi/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: डिप्लॉय
 description: Terraform डिप्लॉयमेंट वॉकथ्रू
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/it/03-deploy.mdx
+++ b/docs/it/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: Distribuzione
 description: Guida passo passo alla distribuzione con Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/ja/03-deploy.mdx
+++ b/docs/ja/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: デプロイ
 description: Terraformデプロイのウォークスルー
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/ko/03-deploy.mdx
+++ b/docs/ko/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: 배포
 description: Terraform 배포 안내
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/pt-br/03-deploy.mdx
+++ b/docs/pt-br/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: Implantação
 description: Passo a passo da implantação com Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/th/03-deploy.mdx
+++ b/docs/th/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: การติดตั้ง
 description: คำแนะนำการติดตั้งด้วย Terraform
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/zh-cn/03-deploy.mdx
+++ b/docs/zh-cn/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: 部署
 description: Terraform 部署操作指南
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 

--- a/docs/zh-tw/03-deploy.mdx
+++ b/docs/zh-tw/03-deploy.mdx
@@ -2,7 +2,7 @@
 title: 部署
 description: Terraform 部署操作指南
 i18n:
-  sourceHash: 8a082ae58970
+  sourceHash: fde32fbc296d
   translator: machine
 ---
 


### PR DESCRIPTION
## Problem

`audit / Translation freshness` fails on 12 machine-translated locale files, blocking governance sync PR #113. Root cause: the org-rename sweep (`f5xc-salesdemos` → `f5-sales-demo`) updated en+locale content but did not restamp `i18n.sourceHash`.

Verified content-current: the only en change since each stored hash is the org rename, already applied in the locale files (guard confirmed org-rename-only for every file; 0 needing re-translation).

## Fix

Restamp `i18n.sourceHash` to `sha256(en)[:12]` in the 12 affected files. One hash line per file; no prose edits.

## Acceptance criteria
- [ ] `audit / Translation freshness` passes.
- [ ] Only `sourceHash` values change.

Unblocks governance sync PR #113.

Closes #114