### PR TITLE
fix: complete org rename f5xc-salesdemos -> f5-sales-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Repository Settings](https://github.com/f5-sales-demo/demo-resource-template/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/demo-resource-template/actions/workflows/enforce-repo-settings.yml)
 [![License](https://img.shields.io/github/license/f5-sales-demo/demo-resource-template)](LICENSE)
 
-Template repository for f5xc-salesdemos demo resources following the Demo Resource Standard
+Template repository for f5-sales-demo demo resources following the Demo Resource Standard
 
 
 ## Documentation


### PR DESCRIPTION
Closes #177

Replaces stale `f5xc-salesdemos` references with `f5-sales-demo` (org rename cleanup; clean break, pre-release). `git grep f5xc-salesdemos` now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)