### PR TITLE
docs: name the org by its current slug in the README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Repository Settings](https://github.com/f5-sales-demo/demo-resource-template/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/demo-resource-template/actions/workflows/enforce-repo-settings.yml)
 [![License](https://img.shields.io/github/license/f5-sales-demo/demo-resource-template)](LICENSE)
 
-Template repository for f5xc-salesdemos demo resources following the Demo Resource Standard
+Template repository for f5-sales-demo demo resources following the Demo Resource Standard
 
 
 ## Documentation


### PR DESCRIPTION
Closes #215

One-line change: the README tagline still named the organisation `f5xc-salesdemos`.

The rename to `f5-sales-demo` went unnoticed here because GitHub redirects git and API traffic for
a renamed owner — I verified that directly, `git push --dry-run` and `gh api` both succeed against
the old slug. **GitHub Pages does not redirect**: `https://f5xc-salesdemos.github.io/...` returns
**404** (verified with curl), so a reader who builds a Pages URL from the old name gets a dead page.

The repository GitHub *description* carried the identical stale string and has already been fixed
via the API, so the two no longer disagree.

Verified: `git grep -F f5xc-salesdemos` returns no hits in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)