### PR TITLE
docs: resolve Markdown lint violations

### DIFF
--- a/docs/en/02-prerequisites.mdx
+++ b/docs/en/02-prerequisites.mdx
@@ -22,7 +22,7 @@ ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 TODO: Update with your component's estimated monthly cost.
 
 | Resource | Estimated Monthly Cost |
-|---|---|
+| --- | --- |
 | VM (REPLACE_SIZE) | REPLACE |
 | Public IP | ~$4 |
 | **Total** | **REPLACE** |

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8,8 +8,8 @@ IP="${1:?Usage: smoke-test.sh <public-ip>}"
 echo "Running smoke tests against $IP..."
 
 # TODO: Add component-specific health checks
-curl --fail --silent --max-time 10 "http://$IP/health" > /dev/null \
-  && echo "PASS: /health" \
-  || echo "FAIL: /health"
+curl --fail --silent --max-time 10 "http://$IP/health" >/dev/null &&
+  echo "PASS: /health" ||
+  echo "FAIL: /health"
 
 echo "Smoke tests complete."


### PR DESCRIPTION
## Summary

- normalize the audited prerequisites table for enforced MD060 formatting
- apply the repository's shell formatting to the smoke-test condition
- keep generated locale trees unchanged

Closes #266

## Testing

- markdownlint-cli 0.49.1 and governed prose lint on every changed Markdown/MDX file
- shellcheck and shfmt over every tracked shell script
- tests/test-check-repo-hygiene.sh
- git diff --check
