### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,9 +222,10 @@ repos:
         types: [text]
         # codespell's own `skip` list only applies during its directory
         # traversal; when pre-commit passes explicit file paths it is bypassed.
-        # Filter translation docs and source catalogs here so their
-        # foreign-language words never reach codespell. See issues #579 and #934.
-        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
+        # Filter generated artifacts, translation docs, and source catalogs
+        # here so generated identifiers and foreign-language words never reach
+        # codespell. See issues #579, #934, and #1234.
+        exclude: ^(dist/|build/|release/|vendor/|docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json


### PR DESCRIPTION
Closes #313

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .pre-commit-config.yaml