### PR TITLE
Remove governed README verification marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,3 @@ branch naming, and CI requirements.
 ## License
 
 See [LICENSE](LICENSE).
-
-<!-- linked-issue verification: #428 -->


### PR DESCRIPTION
Removes only the governed README verification marker from PR #429.

Closes #430
